### PR TITLE
Cast data to short in compute_pesq call

### DIFF
--- a/pypesq/pesq.c
+++ b/pypesq/pesq.c
@@ -58,7 +58,7 @@ static PyObject *_pesq(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    float pesq = compute_pesq(ref->data, deg->data, ref->dimensions[0], deg->dimensions[0], fs);
+    float pesq = compute_pesq((short *) ref->data, (short *) deg->data, ref->dimensions[0], deg->dimensions[0], fs);
 
     return Py_BuildValue("f", pesq);
 }


### PR DESCRIPTION
Ensure proper data type is used in the compute_pesq function by casting input data to short.